### PR TITLE
Fixed small typo in project name

### DIFF
--- a/docs/tools/generate.fsx
+++ b/docs/tools/generate.fsx
@@ -10,7 +10,7 @@ let website = "/FSharpx.ManagementProviders"
 
 // Specify more information about your project
 let info =
-  [ "project-name", "FSharpx.ManagementProvider"
+  [ "project-name", "FSharpx.ManagementProviders"
     "project-author", "Steffen Forkmann"
     "project-summary", "Various type providers for management of the machine."
     "project-github", "http://github.com/forki/FSharpx.ManagementProviders"


### PR DESCRIPTION
Fixed a small typo in the project name for the generated documentation pages. Is this change enough, or should I include the newly generated documentation output?
