### PR TITLE
Implements Issue #20

### DIFF
--- a/tests/FSharp.Management.Tests/FileSystemProvider.Tests.fs
+++ b/tests/FSharp.Management.Tests/FileSystemProvider.Tests.fs
@@ -7,13 +7,13 @@ open FsUnit
 type Users = FileSystem<"C:\\Users\\">
 type RelativeUsers = FileSystem<"C:\\Users", "C:\\Users">
 
-[<Test>] 
+[<Test>]
 let ``Can create type for users path``() = 
     Users.Path |> should equal @"C:\Users\"    
 
 [<Test>] 
 let ``Can access the default users path``() = 
-    Users.Default.Path |> should equal @"C:\Users\Default"
+    Users.Default.Path |> should equal @"C:\Users\Default\"
 
 [<Test>]
 let ``Can access the users path via relative path``() =
@@ -21,11 +21,11 @@ let ``Can access the users path via relative path``() =
 
 [<Test>]
 let ``Can access the default users path via relative path``() =
-    RelativeUsers.Default.Path |> should equal @".\Default"
+    RelativeUsers.Default.Path |> should equal @"Default\"
 
 [<Test>]
 let ``Can access the bin folder within the project``() =
-    RelativePath.Bin.Path |> should equal @".\bin"
+    RelativePath.Bin.Path |> should equal @"bin\"
 
 [<Test>]
 let ``Can access a relative path``() = 
@@ -33,16 +33,16 @@ let ``Can access a relative path``() =
 
 [<Test>] 
 let ``Can access a relative subfolder``() = 
-    RelativePath.Bin.Path |> should equal @".\bin"
+    RelativePath.Bin.Path |> should equal @"bin\"
 
 [<Test>] 
 let ``Can access a relative file``() =
-    RelativePath.``WMI.Tests.fs`` |> should equal @".\WMI.Tests.fs"
+    RelativePath.``WMI.Tests.fs`` |> should equal @"WMI.Tests.fs"
 
 [<Test>] 
 let ``Can access a parent dir``() =
-    RelativePath.Parent.Path |> should equal @".."
+    RelativePath.Parent.Path |> should equal @"..\"
 
 [<Test>] 
 let ``Can access a parent's parent dir``() =
-    RelativePath.Parent.Parent.Path |> should equal @"..\.."
+    RelativePath.Parent.Parent.Path |> should equal @"..\..\"


### PR DESCRIPTION
This implements Issue #20.

Note: There are a couple of side effects from this request.

First, the system directory separator is now used automatically, since all relative paths are generated, at runtime, by the Windows API, and not hardcoded.  This changes the form of the relative paths in two ways:

First, paths will often be prefixed with the current path specifier (".\foo\bar\some file.txt")
Second, folders will no longer have the trailing forward slash that was added manually (".\Foo" instead of "Foo/")

The tests were updated accordingly.

In practice, this should have no negative impact.  Any use of the file path as a path will still work properly, and Path.Combine and related BCL methods should all handle this perfectly. 
