### PR TITLE
Changed "Parent" to delayed member

### DIFF
--- a/src/FSharp.Management/FileSystemProvider.fs
+++ b/src/FSharp.Management/FileSystemProvider.fs
@@ -74,7 +74,7 @@ let rec annotateDirectoryNode (ownerType: ProvidedTypeDefinition) (dir: Director
                 match relative with
                 | Some sourcePath -> Some((fixDirectoryPath sourcePath) + "..\\")
                 | None -> None
-            ownerType.AddMember (createDirectoryNode typeSet dir.Parent "Parent" withParent relative ())
+            ownerType.AddMemberDelayed (createDirectoryNode typeSet dir.Parent "Parent" withParent relative)
         with
         | exn -> ()
 


### PR DESCRIPTION
Changed "Parent" folder to be delayed when using relative paths.  This
prevents cascading creation of all types to the root folder of the
drive.  Without the delayed creation, types for all folders up to the root (ie: C:) 
would get created immediately upon using the RelativePath type.
