### PR TITLE
Changed "Parent" to use ".." instead of "Parent" in RelativePath

### DIFF
--- a/docs/content/FileSystemProvider.fsx
+++ b/docs/content/FileSystemProvider.fsx
@@ -54,5 +54,5 @@ With the help of the FileSystemProvider we can browse the project via Intellisen
 open FSharp.Management
 
 // browse the project
-RelativePath.Parent.files.img.``PowerShellProvider.png``
+RelativePath.``..``.files.img.``PowerShellProvider.png``
 // [fsi:val it : string = "..\files\img\PowerShellProvider.png"

--- a/src/FSharp.Management/FileSystemProvider.fs
+++ b/src/FSharp.Management/FileSystemProvider.fs
@@ -74,7 +74,7 @@ let rec annotateDirectoryNode (ownerType: ProvidedTypeDefinition) (dir: Director
                 match relative with
                 | Some sourcePath -> Some((fixDirectoryPath sourcePath) + "..\\")
                 | None -> None
-            ownerType.AddMemberDelayed (createDirectoryNode typeSet dir.Parent "Parent" withParent relative)
+            ownerType.AddMemberDelayed (createDirectoryNode typeSet dir.Parent ".." withParent relative)
         with
         | exn -> ()
 

--- a/tests/FSharp.Management.Tests/FileSystemProvider.Tests.fs
+++ b/tests/FSharp.Management.Tests/FileSystemProvider.Tests.fs
@@ -41,8 +41,8 @@ let ``Can access a relative file``() =
 
 [<Test>] 
 let ``Can access a parent dir``() =
-    RelativePath.Parent.Path |> should equal @"..\"
+    RelativePath.``..``.Path |> should equal @"..\"
 
 [<Test>] 
 let ``Can access a parent's parent dir``() =
-    RelativePath.Parent.Parent.Path |> should equal @"..\..\"
+    RelativePath.``..``.``..``.Path |> should equal @"..\..\"


### PR DESCRIPTION
Changed "Parent" to use ".." instead of "Parent" in RelativePath to address Issue #27 (Rework to address merge conflicts)
