### PR TITLE
Added test as example for Issue #36

### DIFF
--- a/tests/FSharp.Management.Tests/FileSystemProvider.Tests.fs
+++ b/tests/FSharp.Management.Tests/FileSystemProvider.Tests.fs
@@ -9,6 +9,7 @@ type RelativeUsers = FileSystem<"C:\\Users", "C:\\Users">
 
 type Relative = RelativePath<"">
 type RelativeToBin = RelativePath<"bin">
+type RelativeToBuild = RelativePath<"bin\\Debug">
 
 [<Test>]
 let ``Can create type for users path``() = 
@@ -57,3 +58,12 @@ let ``Can access a parent dir``() =
 [<Test>] 
 let ``Can access a parent's parent dir``() =
     Relative.``..``.``..``.Path |> should equal @"..\..\"
+
+[<Test>]
+let ``Can access solution files using RelativePath provider``() =
+    let fsDocPath = RelativeToBuild.``..``.``..``.``..``.``..``.docs.content.``FileSystemProvider.fsx``
+    let buildFolder = CommonFolders.GetApplication ApplicationPath.FSharpManagementLocation
+
+    let path = System.IO.Path.GetFullPath(System.IO.Path.Combine(buildFolder, fsDocPath))
+
+    System.IO.File.Exists(path) |> should equal true


### PR DESCRIPTION
Added a test which does exactly what was desired in Issue #36 - Combines RelativePath with CommonFolders to access a file within the solution directly in a unit test, without copying the file.
