### PR TITLE
Support for .NET 4.0

### DIFF
--- a/src/FSharp.Management.PowerShell.ExternalRuntime/App.config
+++ b/src/FSharp.Management.PowerShell.ExternalRuntime/App.config
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <configuration>
   <startup>
-    <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5" />
+    <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.0" />
   </startup>
   <runtime>
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
@@ -19,7 +19,9 @@
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="FSharp.Core" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-4.3.0.0" newVersion="4.3.0.0" />
+        <bindingRedirect oldVersion="2.0.0.0" newVersion="4.3.0.0" />
+        <bindingRedirect oldVersion="2.3.5.0" newVersion="4.3.0.0" />
+        <bindingRedirect oldVersion="4.0.0.0" newVersion="4.3.0.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="FSharp.Interactive.Service" publicKeyToken="f536804aa0eb945b" culture="neutral" />

--- a/src/FSharp.Management.PowerShell.ExternalRuntime/FSharp.Management.PowerShell.ExternalRuntime.fsproj
+++ b/src/FSharp.Management.PowerShell.ExternalRuntime/FSharp.Management.PowerShell.ExternalRuntime.fsproj
@@ -9,7 +9,7 @@
     <OutputType>Exe</OutputType>
     <RootNamespace>FSharp.Management.PowerShell.ExternalRuntime</RootNamespace>
     <AssemblyName>FSharp.Management.PowerShell.ExternalRuntime</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
     <TargetFSharpCoreVersion>4.3.0.0</TargetFSharpCoreVersion>
     <Name>FSharp.Management.PowerShell.ExternalRuntime</Name>

--- a/src/FSharp.Management.PowerShell/FSharp.Management.PowerShell.fsproj
+++ b/src/FSharp.Management.PowerShell/FSharp.Management.PowerShell.fsproj
@@ -9,7 +9,7 @@
     <OutputType>Library</OutputType>
     <RootNamespace>FSharp.Management.PowerShell</RootNamespace>
     <AssemblyName>FSharp.Management.PowerShell</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
     <TargetFSharpCoreVersion>4.3.0.0</TargetFSharpCoreVersion>
     <Name>FSharp.Management.PowerShell</Name>
   </PropertyGroup>

--- a/src/FSharp.Management.PowerShell/TypeInference.fs
+++ b/src/FSharp.Management.PowerShell/TypeInference.fs
@@ -39,7 +39,11 @@ let private getOutputTypesFromSharePointCmdlets(cmdlet:CmdletConfigurationEntry)
         |> Seq.fold (fun state value -> state || value) false
     if (not <| isSPassembly) then None
     else
-        match baseTy.GenericTypeArguments with
+        let types = 
+            baseTy.GetGenericArguments()
+            |> Seq.filter (fun t -> not t.IsGenericParameter)
+            |> Seq.toArray
+        match types with
         | [|x|] -> Some([|x|])
         | _ -> None
 

--- a/src/FSharp.Management.WMI.DesignTime/FSharp.Management.WMI.DesignTime.fsproj
+++ b/src/FSharp.Management.WMI.DesignTime/FSharp.Management.WMI.DesignTime.fsproj
@@ -9,7 +9,7 @@
     <OutputType>Library</OutputType>
     <RootNamespace>FSharp.Management</RootNamespace>
     <AssemblyName>FSharp.Management.WMI.DesignTime</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
     <TargetFSharpCoreVersion>4.3.0.0</TargetFSharpCoreVersion>
     <Name>FSharp.Management</Name>
     <TargetFrameworkProfile />

--- a/src/FSharp.Management.WMI/FSharp.Management.WMI.fsproj
+++ b/src/FSharp.Management.WMI/FSharp.Management.WMI.fsproj
@@ -9,7 +9,7 @@
     <OutputType>Library</OutputType>
     <RootNamespace>FSharp.Management</RootNamespace>
     <AssemblyName>FSharp.Management.WMI</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
     <TargetFSharpCoreVersion>4.3.0.0</TargetFSharpCoreVersion>
     <Name>FSharp.Management</Name>
     <TargetFrameworkProfile />

--- a/src/FSharp.Management/FSharp.Management.fsproj
+++ b/src/FSharp.Management/FSharp.Management.fsproj
@@ -9,7 +9,7 @@
     <OutputType>Library</OutputType>
     <RootNamespace>FSharp.Management</RootNamespace>
     <AssemblyName>FSharp.Management</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
     <TargetFSharpCoreVersion>4.3.0.0</TargetFSharpCoreVersion>
     <Name>FSharp.Management</Name>
     <TargetFrameworkProfile />

--- a/tests/FSharp.Management.Tests/FSharp.Management.Tests.fsproj
+++ b/tests/FSharp.Management.Tests/FSharp.Management.Tests.fsproj
@@ -9,7 +9,7 @@
     <OutputType>Library</OutputType>
     <RootNamespace>FSharp.Management.Tests</RootNamespace>
     <AssemblyName>FSharp.Management.Tests</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
     <TargetFSharpCoreVersion>4.3.0.0</TargetFSharpCoreVersion>
     <Name>FSharp.Management.Tests</Name>
     <TargetFrameworkProfile />


### PR DESCRIPTION
* replaced usage of Type.GenericTypeArguments with GetGenericArguments
* change project files to .NET 4.0
* redirect binding (I guess added by visual studio)