### PR TITLE
Return unconverted collection if we don't know result type

### DIFF
--- a/src/FSharp.Management.PowerShell/HostedRuntime.fs
+++ b/src/FSharp.Management.PowerShell/HostedRuntime.fs
@@ -128,8 +128,8 @@ type PSRuntimeHosted(snapIns:string[], modules:string[]) =
                     let errors = ps.Streams.Error |> Seq.cast<ErrorRecord> |> List.ofSeq   
                     cmd.ResultType.GetMethod("NewFailure").Invoke(null, [|errors|])
                 else
-                    let empty = new PSObject()
-                    cmd.ResultType.GetMethod("NewSuccess").Invoke(null, [|empty|])    // Result of execution is empty object
+                    let boxedResult = new PSObject(result)
+                    cmd.ResultType.GetMethod("NewSuccess").Invoke(null, [|boxedResult|])    // Result of execution is empty object
 
             | Some(tyOfObj) ->
                 let collectionConverter =

--- a/tests/FSharp.Management.Tests/PowerShellProvider.Tests.fs
+++ b/tests/FSharp.Management.Tests/PowerShellProvider.Tests.fs
@@ -42,6 +42,14 @@ let ``Get events from event log`` () =
         entries |> shouldHaveLength 2
     | _ -> failwith "Unexpected result"
 
+// This Cmdlet has an empty OutputType
+[<Test>]
+let ``Get help message`` () =
+    match PS.``Get-Help``() with
+    | Success(resultObj) ->
+        resultObj.GetType() |> shouldEqual typeof<System.Management.Automation.PSObject>
+    | _ -> failwith "Unexpected result"
+
 let [<Literal>]ModuleFile = __SOURCE_DIRECTORY__ + @"\testModule.psm1"
 type PSFileModule =  PowerShellProvider< ModuleFile >
 


### PR DESCRIPTION
Previously, results weren't being returned if OutputType property of the Cmdlet was empty

#64