### PR TITLE
Catch runtime exceptions when executing a Cmdlet and return the error

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -182,3 +182,4 @@ docs/content/license.md
 docs/content/release-notes.md
 .fake
 docs/tools/FSharp.Formatting.svclog
+/.paket/Paket.Restore.targets

--- a/src/FSharp.Management.PowerShell/Types.fs
+++ b/src/FSharp.Management.PowerShell/Types.fs
@@ -1,6 +1,13 @@
 ﻿[<AutoOpen>]
 module FSharp.Management.PowerShellProviderTypes
 
+open System.Management.Automation
+open System.Collections.ObjectModel
+
 type PsCmdletResult<'TSuccess,'TFailure> = 
     | Success of 'TSuccess
     | Failure of 'TFailure
+
+type PsExecutionResult =
+    | Result of Collection<PSObject>
+    | Error of ErrorRecord


### PR DESCRIPTION
 This solves case 3 mentioned in #86. Any Runtime exceptions should now fail gracefully